### PR TITLE
fix(popx): Connection.Store compatible with sqlx.QueryerContext

### DIFF
--- a/popx/postgres_transaction_helpers.go
+++ b/popx/postgres_transaction_helpers.go
@@ -79,7 +79,8 @@ func (c *Client) GetConnection(ctx context.Context) *pop.Connection {
 			return conn.WithContext(ctx)
 		}
 	}
-	return c.c.WithContext(ctx)
+	// WithContext() returns connection with store which incompatible with sqlx.QueryerContext
+	return c.c
 }
 
 // GetSqlxQueryer returns sqlx.QueryerContext wrapped by pop


### PR DESCRIPTION
`GetConnection` returns connection with store which is incompatible with `sqlx.QueryerContext` so that `GetSqlxQueryer` and `GetSqlxExecer` could not use.
