### PR TITLE
fix: Use stdlib errors instead of github.com/pkg/errors

### DIFF
--- a/bunx/lock.go
+++ b/bunx/lock.go
@@ -2,13 +2,14 @@ package bunx
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/uptrace/bun"
 )
 
 var (
-	ErrDataLockTaken = errors.Errorf("data lock taken")
+	ErrDataLockTaken = errors.New("data lock taken")
 )
 
 // TransactionWithTryAdvisoryLock is Transaction with pg_try_advisory_xact_lock
@@ -37,7 +38,7 @@ func tryTakeAdvisoryLock(ctx context.Context, tx bun.Tx, key string) error {
 		return err
 	}
 	if !result {
-		return errors.WithMessagef(ErrDataLockTaken, "data lock taken at the key %s", key)
+		return fmt.Errorf("data lock taken at the key %s: %w", key, ErrDataLockTaken)
 	}
 	return nil
 }

--- a/bunx/lock_test.go
+++ b/bunx/lock_test.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"database/sql"
 	"embed"
+	"errors"
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uptrace/bun"

--- a/dockertestx/dynamodb.go
+++ b/dockertestx/dynamodb.go
@@ -8,7 +8,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/ory/dockertest/v3"
-	"github.com/pkg/errors"
 )
 
 type DynamoDBFactory struct{}
@@ -26,7 +25,7 @@ func (f *DynamoDBFactory) create(p *Pool, opt ContainerOption) (*state, error) {
 	}
 	resource, err := p.Pool.RunWithOptions(rOpt)
 	if err != nil {
-		return nil, errors.WithMessage(err, "Could not start resource")
+		return nil, fmt.Errorf("could not start resource: %w", err)
 	}
 	return &state{
 		ContainerName: opt.Name,

--- a/dockertestx/postgres.go
+++ b/dockertestx/postgres.go
@@ -6,7 +6,6 @@ import (
 
 	_ "github.com/lib/pq"
 	"github.com/ory/dockertest/v3"
-	"github.com/pkg/errors"
 )
 
 type PostgresFactory struct{}
@@ -32,7 +31,7 @@ func (f *PostgresFactory) create(p *Pool, opt ContainerOption) (*state, error) {
 	}
 	resource, err := p.Pool.RunWithOptions(rOpt)
 	if err != nil {
-		return nil, errors.WithMessage(err, "Could not start resource")
+		return nil, fmt.Errorf("could not start resource: %w", err)
 	}
 	return &state{
 		ContainerName: opt.Name,

--- a/dockertestx/s3.go
+++ b/dockertestx/s3.go
@@ -7,7 +7,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/ory/dockertest/v3"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -34,7 +33,7 @@ func (f *S3Factory) create(p *Pool, opt ContainerOption) (*state, error) {
 	}
 	resource, err := p.Pool.RunWithOptions(rOpt)
 	if err != nil {
-		return nil, errors.WithMessage(err, "Could not start resource")
+		return nil, fmt.Errorf("could not start resource: %w", err)
 	}
 	return &state{
 		ContainerName: opt.Name,

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,6 @@ require (
 	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 // indirect
 	github.com/opencontainers/runc v1.0.3 // indirect
 	github.com/ory/dockertest/v3 v3.8.1
-	github.com/pkg/errors v0.9.1
 	github.com/rogpeppe/go-internal v1.8.1 // indirect
 	github.com/stretchr/testify v1.7.0
 	github.com/uptrace/bun v1.0.21

--- a/popx/popx.go
+++ b/popx/popx.go
@@ -5,7 +5,6 @@ import (
 	"io"
 
 	"github.com/gobuffalo/pop/v5"
-	"github.com/pkg/errors"
 )
 
 type Client struct {
@@ -41,7 +40,7 @@ func (c *Client) MigrateUp(_ context.Context) error {
 }
 
 func (c *Client) Close(ctx context.Context) error {
-	return errors.WithStack(c.GetConnection(ctx).Close())
+	return c.GetConnection(ctx).Close()
 }
 
 func (c *Client) Ping() error {
@@ -49,5 +48,5 @@ func (c *Client) Ping() error {
 		Ping() error
 	}
 	// This can not be contextualized because of some gobuffalo/pop limitations.
-	return errors.WithStack(c.c.Store.(pinger).Ping())
+	return c.c.Store.(pinger).Ping()
 }

--- a/popx/postgres_transaction_helpers.go
+++ b/popx/postgres_transaction_helpers.go
@@ -2,14 +2,15 @@ package popx
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"github.com/gobuffalo/pop/v5"
 	"github.com/jmoiron/sqlx"
-	"github.com/pkg/errors"
 )
 
 var (
-	ErrDataLockTaken = errors.Errorf("data lock taken")
+	ErrDataLockTaken = errors.New("data lock taken")
 )
 
 type transactionContextKey int
@@ -67,7 +68,7 @@ func tryTakeAdvisoryLock(tx *pop.Connection, key string) error {
 		return err
 	}
 	if !result {
-		return errors.WithMessagef(ErrDataLockTaken, "data lock taken at the key %s", key)
+		return fmt.Errorf("data lock taken at the key %s: %w", key, ErrDataLockTaken)
 	}
 	return nil
 }

--- a/popx/postgres_transaction_helpers_test.go
+++ b/popx/postgres_transaction_helpers_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"database/sql"
 	"embed"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/gobuffalo/pop/v5"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"


### PR DESCRIPTION
Replece `errors` instead of `github.com/pkg/errors` which is archived.