### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,10 +12,6 @@ updates:
       day: "thursday"
       time: "07:00"
       timezone: "Asia/Tokyo"
-    reviewers:
-      - sawadashota
-      - kensei18
-      - ryosan-470
     groups:
       patch-minor:
         update-types:
@@ -29,10 +25,6 @@ updates:
       day: "thursday"
       time: "07:00"
       timezone: "Asia/Tokyo"
-    reviewers:
-      - sawadashota
-      - kensei18
-      - ryosan-470
     groups:
       patch-minor:
         update-types:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @sawadashota @kensei18 @ryosan-470


### PR DESCRIPTION
add CODEOWNERS file instad of reviewers in dependabot.yml.
see more detail:
https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/