### PR TITLE
feat(dockertestx): add admiralpiett/goaws as SNS/SQS testing

### DIFF
--- a/bunx/go.mod
+++ b/bunx/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.18.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.81.0 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sns v1.34.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.38.8 // indirect
 	github.com/aws/smithy-go v1.22.4 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect

--- a/bunx/go.sum
+++ b/bunx/go.sum
@@ -42,6 +42,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.18.17 h1:qcLWgdhq45sDM
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.18.17/go.mod h1:M+jkjBFZ2J6DJrjMv2+vkBbuht6kxJYtJiwoVgX4p4U=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.81.0 h1:1GmCadhKR3J2sMVKs2bAYq9VnwYeCqfRyZzD4RASGlA=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.81.0/go.mod h1:kUklwasNoCn5YpyAqC/97r6dzTA1SRKJfKq16SXeoDU=
+github.com/aws/aws-sdk-go-v2/service/sns v1.34.7 h1:OBuZE9Wt8h2imuRktu+WfjiTGrnYdCIJg8IX92aalHE=
+github.com/aws/aws-sdk-go-v2/service/sns v1.34.7/go.mod h1:4WYoZAhHt+dWYpoOQUgkUKfuQbE6Gg/hW4oXE0pKS9U=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.38.8 h1:80dpSqWMwx2dAm30Ib7J6ucz1ZHfiv5OCRwN/EnCOXQ=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.38.8/go.mod h1:IzNt/udsXlETCdvBOL0nmyMe2t9cGmXmZgsdoZGYYhI=
 github.com/aws/aws-sdk-go-v2/service/sso v1.25.5 h1:AIRJ3lfb2w/1/8wOOSqYb9fUKGwQbtysJ2H1MofRUPg=

--- a/dockertestx/go.mod
+++ b/dockertestx/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.10.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.18.17 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sns v1.34.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.25.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.30.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.34.0 // indirect

--- a/dockertestx/go.sum
+++ b/dockertestx/go.sum
@@ -42,6 +42,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.18.17 h1:qcLWgdhq45sDM
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.18.17/go.mod h1:M+jkjBFZ2J6DJrjMv2+vkBbuht6kxJYtJiwoVgX4p4U=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.81.0 h1:1GmCadhKR3J2sMVKs2bAYq9VnwYeCqfRyZzD4RASGlA=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.81.0/go.mod h1:kUklwasNoCn5YpyAqC/97r6dzTA1SRKJfKq16SXeoDU=
+github.com/aws/aws-sdk-go-v2/service/sns v1.34.7 h1:OBuZE9Wt8h2imuRktu+WfjiTGrnYdCIJg8IX92aalHE=
+github.com/aws/aws-sdk-go-v2/service/sns v1.34.7/go.mod h1:4WYoZAhHt+dWYpoOQUgkUKfuQbE6Gg/hW4oXE0pKS9U=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.38.8 h1:80dpSqWMwx2dAm30Ib7J6ucz1ZHfiv5OCRwN/EnCOXQ=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.38.8/go.mod h1:IzNt/udsXlETCdvBOL0nmyMe2t9cGmXmZgsdoZGYYhI=
 github.com/aws/aws-sdk-go-v2/service/sso v1.25.5 h1:AIRJ3lfb2w/1/8wOOSqYb9fUKGwQbtysJ2H1MofRUPg=

--- a/dockertestx/sns_sqs.go
+++ b/dockertestx/sns_sqs.go
@@ -1,0 +1,46 @@
+package dockertestx
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sns"
+	"github.com/ory/dockertest/v3"
+)
+
+type SNSSQSFactory struct{}
+
+func (f *SNSSQSFactory) repository() string {
+	return "admiralpiett/goaws"
+}
+
+func (f *SNSSQSFactory) create(p *Pool, opt ContainerOption) (*state, error) {
+	rOpt := &dockertest.RunOptions{
+		Name:       opt.Name,
+		Repository: f.repository(),
+		Tag:        opt.Tag,
+	}
+	resource, err := p.Pool.RunWithOptions(rOpt)
+	if err != nil {
+		return nil, fmt.Errorf("could not start resource: %w", err)
+	}
+	return &state{
+		ContainerName: opt.Name,
+		Repository:    f.repository(),
+		Tag:           opt.Tag,
+		Env:           rOpt.Env,
+		DSN:           fmt.Sprintf("http://127.0.0.1:%s", resource.GetPort("4100/tcp")),
+		r:             resource,
+	}, nil
+}
+
+func (f *SNSSQSFactory) ready(p *Pool, s *state) error {
+	return p.Pool.Retry(func() error {
+		cl := sns.New(sns.Options{
+			BaseEndpoint: aws.String(s.DSN),
+		})
+		_, err := cl.ListTopics(context.TODO(), &sns.ListTopicsInput{})
+		return err
+	})
+}

--- a/dockertestx/sns_sqs_test.go
+++ b/dockertestx/sns_sqs_test.go
@@ -1,0 +1,121 @@
+package dockertestx_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sns"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tier4/x-go/dockertestx"
+)
+
+func TestPool_SNSSQSFactory(t *testing.T) {
+	t.Parallel()
+
+	p, err := dockertestx.New(dockertestx.PoolOption{})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, p.Purge())
+	})
+
+	endpoint, err := p.NewResource(new(dockertestx.SNSSQSFactory), dockertestx.ContainerOption{})
+	require.NoError(t, err)
+
+	snsCli := sns.New(sns.Options{
+		BaseEndpoint: aws.String(endpoint),
+		Region:       "ap-northeast-1",
+		Credentials: aws.CredentialsProviderFunc(func(ctx context.Context) (aws.Credentials, error) {
+			return aws.Credentials{
+				AccessKeyID:     "dummy",
+				SecretAccessKey: "dummy",
+			}, nil
+		}),
+	})
+
+	sqsCli := sqs.New(sqs.Options{
+		BaseEndpoint: aws.String(endpoint),
+		Region:       "ap-northeast-1",
+		Credentials: aws.CredentialsProviderFunc(func(ctx context.Context) (aws.Credentials, error) {
+			return aws.Credentials{
+				AccessKeyID:     "dummy",
+				SecretAccessKey: "dummy",
+			}, nil
+		}),
+	})
+
+	ctx := context.Background()
+
+	var (
+		topicArn string
+		queueUrl string
+	)
+
+	// Create a topic and a queue
+	{
+		createTopicRes, err := snsCli.CreateTopic(ctx, &sns.CreateTopicInput{
+			Name: aws.String("test-topic.fifo"),
+			Attributes: map[string]string{
+				"FifoTopic": "true",
+			},
+		})
+		require.NoError(t, err)
+		assert.NotNil(t, createTopicRes.TopicArn)
+
+		createQueueRes, err := sqsCli.CreateQueue(ctx, &sqs.CreateQueueInput{
+			QueueName: aws.String("test-queue.fifo"),
+			Attributes: map[string]string{
+				"FifoQueue": "true",
+			},
+		})
+		require.NoError(t, err)
+		assert.NotNil(t, createQueueRes.QueueUrl)
+
+		topicArn = *createTopicRes.TopicArn
+		queueUrl = *createQueueRes.QueueUrl
+	}
+
+	// Subscribe the queue to the topic
+	_, err = snsCli.Subscribe(ctx, &sns.SubscribeInput{
+		Protocol: aws.String("sqs"),
+		Attributes: map[string]string{
+			"RawMessageDelivery": "true",
+		},
+		TopicArn: aws.String(topicArn),
+		Endpoint: aws.String(queueUrl),
+	})
+	require.NoError(t, err)
+
+	// Publish a message to the topic
+	_, err = snsCli.Publish(ctx, &sns.PublishInput{
+		Message:        aws.String("Hello, SNS!"),
+		TopicArn:       aws.String(topicArn),
+		MessageGroupId: aws.String("test-group"),
+	})
+	require.NoError(t, err)
+
+	// Receive the message from the queue
+	receiveRes, err := sqsCli.ReceiveMessage(ctx, &sqs.ReceiveMessageInput{
+		QueueUrl:                    aws.String(queueUrl),
+		MaxNumberOfMessages:         1,
+		MessageAttributeNames:       []string{"All"},
+		MessageSystemAttributeNames: []types.MessageSystemAttributeName{types.MessageSystemAttributeNameAll},
+		ReceiveRequestAttemptId:     nil,
+		VisibilityTimeout:           1,
+		WaitTimeSeconds:             1,
+	})
+	require.NoError(t, err)
+	assert.Len(t, receiveRes.Messages, 1)
+	assert.Equal(t, "Hello, SNS!", aws.ToString(receiveRes.Messages[0].Body))
+
+	// Clean up: delete the queue and topic
+	_, err = sqsCli.DeleteMessage(ctx, &sqs.DeleteMessageInput{
+		QueueUrl:      aws.String(queueUrl),
+		ReceiptHandle: receiveRes.Messages[0].ReceiptHandle,
+	})
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Added `admiralpiett/goaws` to support both SNS and SQS. Since SNS alone does not allow you to verify published messages, combining it with SQS makes it easier to implement integration tests.
https://github.com/Admiral-Piett/goaws