### PR TITLE
chore: remove reviewers section from dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,10 +38,6 @@ updates:
       day: "thursday"
       time: "07:00"
       timezone: "Asia/Tokyo"
-    reviewers:
-      - sawadashota
-      - kensei18
-      - ryosan-470
     groups:
       patch-minor:
         update-types:


### PR DESCRIPTION
I believe this section was supposed to be removed from this issue. #123