### PR TITLE
fix!: drop support for Go 1.23 and earlier versions.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: golangci-lint
         uses: reviewdog/action-golangci-lint@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,14 +12,14 @@ jobs:
     strategy:
       matrix:
         go:
-          - '1.22'
-          - '1.23'
+          - '1.24'
+          - '1.25'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go }}
       - run: go mod download
@@ -34,14 +34,14 @@ jobs:
     strategy:
       matrix:
         go:
-          - '1.22'
-          - '1.23'
+          - '1.24'
+          - '1.25'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go }}
       - run: go mod download
@@ -56,13 +56,14 @@ jobs:
     strategy:
       matrix:
         go:
-          - '1.23'
+          - '1.24'
+          - '1.25'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go }}
       - run: go mod download

--- a/bunx/go.mod
+++ b/bunx/go.mod
@@ -1,6 +1,6 @@
 module github.com/tier4/x-go/bunx
 
-go 1.23.3
+go 1.24
 
 replace github.com/tier4/x-go/dockertestx => ../dockertestx
 

--- a/dockertestx/go.mod
+++ b/dockertestx/go.mod
@@ -1,6 +1,6 @@
 module github.com/tier4/x-go/dockertestx
 
-go 1.22.8
+go 1.24
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.39.0

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/tier4/x-go
 
-go 1.22
-
-toolchain go1.23.3
+go 1.24
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
In response to issue #151, bunx now requires a minimum version of 1.24. Taking this opportunity, we will drop support for Go versions 1.23 and older, and instead, focus our support solely on versions 1.24 and 1.25.

