### PR TITLE
ci: replace reviewdog/action-golangci-lint with golangci/golangci-lint-action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,10 +11,50 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
+
+      - name: Setup go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
 
       - name: golangci-lint
-        uses: reviewdog/action-golangci-lint@v2
+        uses: golangci/golangci-lint-action@v9
+
+  golangci-dockertestx:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: dockertestx
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup go
+        uses: actions/setup-go@v6
         with:
-          reporter: github-pr-review
-          filter_mode: diff_context
+          go-version-file: dockertestx/go.mod
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          working-directory: dockertestx
+
+  golangci-bunx:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: bunx
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: bunx/go.mod
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          working-directory: bunx

--- a/dockertestx/dynamodb.go
+++ b/dockertestx/dynamodb.go
@@ -23,7 +23,7 @@ func (f *DynamoDBFactory) create(p *Pool, opt ContainerOption) (*state, error) {
 		Tag:        opt.Tag,
 		Env:        []string{},
 	}
-	resource, err := p.Pool.RunWithOptions(rOpt)
+	resource, err := p.RunWithOptions(rOpt)
 	if err != nil {
 		return nil, fmt.Errorf("could not start resource: %w", err)
 	}
@@ -38,7 +38,7 @@ func (f *DynamoDBFactory) create(p *Pool, opt ContainerOption) (*state, error) {
 }
 
 func (f *DynamoDBFactory) ready(p *Pool, s *state) error {
-	return p.Pool.Retry(func() error {
+	return p.Retry(func() error {
 		cl := dynamodb.New(dynamodb.Options{
 			Credentials:  credentials.NewStaticCredentialsProvider("dummy", "dummy", ""),
 			BaseEndpoint: aws.String(s.DSN),

--- a/dockertestx/postgres.go
+++ b/dockertestx/postgres.go
@@ -29,7 +29,7 @@ func (f *PostgresFactory) create(p *Pool, opt ContainerOption) (*state, error) {
 			fmt.Sprintf("POSTGRES_DB=%s", dbName),
 		},
 	}
-	resource, err := p.Pool.RunWithOptions(rOpt)
+	resource, err := p.RunWithOptions(rOpt)
 	if err != nil {
 		return nil, fmt.Errorf("could not start resource: %w", err)
 	}

--- a/dockertestx/prism.go
+++ b/dockertestx/prism.go
@@ -58,7 +58,7 @@ func (f *PrismFactory) create(p *Pool, opt ContainerOption) (*state, error) {
 		rOpt.Cmd = append(rOpt.Cmd, "/tmp/oas.yml")
 	}
 
-	resource, err := p.Pool.RunWithOptions(rOpt)
+	resource, err := p.RunWithOptions(rOpt)
 	if err != nil {
 		return nil, fmt.Errorf("could not start resource: %w", err)
 	}
@@ -79,14 +79,14 @@ func (f *PrismFactory) ready(p *Pool, s *state) error {
 		return fmt.Errorf("invalid heath check path: %w", err)
 	}
 	// Prism (a Node.js app) takes longer than the default 1-minute MaxWait to start in CI.
-	p.Pool.MaxWait = 3 * time.Minute
-	return p.Pool.Retry(func() error {
+	p.MaxWait = 3 * time.Minute
+	return p.Retry(func() error {
 		// Fail immediately if the container has already exited.
-		c, err := p.Pool.Client.InspectContainer(s.r.Container.ID)
+		c, err := p.Client.InspectContainer(s.r.Container.ID)
 		if err == nil && !c.State.Running {
 			// Retrieve container logs for diagnostics.
 			var stdout, stderr bytes.Buffer
-			_ = p.Pool.Client.Logs(dc.LogsOptions{
+			_ = p.Client.Logs(dc.LogsOptions{
 				Container:    s.r.Container.ID,
 				OutputStream: &stdout,
 				ErrorStream:  &stderr,

--- a/dockertestx/s3.go
+++ b/dockertestx/s3.go
@@ -33,7 +33,7 @@ func (f *S3Factory) create(p *Pool, opt ContainerOption) (*state, error) {
 		},
 		Cmd: []string{"server", "/data"},
 	}
-	resource, err := p.Pool.RunWithOptions(rOpt)
+	resource, err := p.RunWithOptions(rOpt)
 	if err != nil {
 		return nil, fmt.Errorf("could not start resource: %w", err)
 	}
@@ -48,7 +48,7 @@ func (f *S3Factory) create(p *Pool, opt ContainerOption) (*state, error) {
 }
 
 func (f *S3Factory) ready(p *Pool, s *state) error {
-	return p.Pool.Retry(func() error {
+	return p.Retry(func() error {
 		cl := s3.New(s3.Options{
 			Credentials:  credentials.NewStaticCredentialsProvider(S3AWSAccessKeyID, S3AWSSecretAccessKey, ""),
 			BaseEndpoint: aws.String(s.DSN),

--- a/dockertestx/sqs.go
+++ b/dockertestx/sqs.go
@@ -21,7 +21,7 @@ func (f *SQSFactory) create(p *Pool, opt ContainerOption) (*state, error) {
 		Repository: f.repository(),
 		Tag:        opt.Tag,
 	}
-	resource, err := p.Pool.RunWithOptions(rOpt)
+	resource, err := p.RunWithOptions(rOpt)
 	if err != nil {
 		return nil, fmt.Errorf("could not start resource: %w", err)
 	}
@@ -36,7 +36,7 @@ func (f *SQSFactory) create(p *Pool, opt ContainerOption) (*state, error) {
 }
 
 func (f *SQSFactory) ready(p *Pool, s *state) error {
-	return p.Pool.Retry(func() error {
+	return p.Retry(func() error {
 		cl := sqs.New(sqs.Options{
 			BaseEndpoint: aws.String(s.DSN),
 		})

--- a/zstdx/zstdx.go
+++ b/zstdx/zstdx.go
@@ -145,6 +145,12 @@ func Compress(src, dest string) error {
 	tarWriter := tar.NewWriter(enc)
 	defer tarWriter.Close()
 
+	root, err := os.OpenRoot(src)
+	if err != nil {
+		return err
+	}
+	defer root.Close()
+
 	dir := filepath.Base(src)
 	// walk through every file in the folder
 	return filepath.Walk(src, func(file string, fi os.FileInfo, e error) error {
@@ -173,7 +179,11 @@ func Compress(src, dest string) error {
 		}
 		// if not a dir, write file content
 		if !fi.IsDir() {
-			data, err := os.Open(file)
+			rel, err := filepath.Rel(src, file)
+			if err != nil {
+				return err
+			}
+			data, err := root.Open(rel)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## Summary
- `reviewdog/action-golangci-lint@v2` を公式の `golangci/golangci-lint-action@v9` に置換
- test.yml のパターンに合わせて各 Go モジュール（root, dockertestx, bunx）ごとにジョブを分割


https://tier4.atlassian.net/browse/T4DEV-51802