### PR TITLE
refactor(zstdx): replace h2non/filetype with direct magic bytes comparison

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.24
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/h2non/filetype v1.1.3
 	github.com/klauspost/compress v1.18.5
 	github.com/stretchr/testify v1.11.1
 )

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/h2non/filetype v1.1.3 h1:FKkx9QbD7HR/zjK1Ia5XiBsq9zdLi5Kf3zGyFTAFkGg=
-github.com/h2non/filetype v1.1.3/go.mod h1:319b3zT68BvV+WRj7cwy856M2ehB3HqNOt6sy1HndBY=
 github.com/klauspost/compress v1.18.5 h1:/h1gH5Ce+VWNLSWqPzOVn6XBO+vJbCNGvjoaGBFW2IE=
 github.com/klauspost/compress v1.18.5/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/zstdx/zstdx.go
+++ b/zstdx/zstdx.go
@@ -2,15 +2,18 @@ package zstdx
 
 import (
 	"archive/tar"
+	"bytes"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 
-	"github.com/h2non/filetype"
 	"github.com/klauspost/compress/zstd"
 )
+
+// zstdMagic is the magic number for Zstandard compressed data (RFC 8478).
+var zstdMagic = []byte{0x28, 0xB5, 0x2F, 0xFD}
 
 // For protection from decompression bomb
 const defaultMaxFileSize int64 = 16 * 1024 * 1024 * 1024
@@ -37,7 +40,7 @@ func uncompress(tarball, targetDir string, maxFileSize int64) ([]string, error) 
 	if err != nil {
 		return nil, fmt.Errorf("cannot read file information: %w", err)
 	}
-	header := make([]byte, min(262, stat.Size()))
+	header := make([]byte, min(4, stat.Size()))
 	if _, err := io.ReadFull(file, header); err != nil {
 		return nil, fmt.Errorf("cannot determine type by reading file header: %w", err)
 	}
@@ -45,7 +48,7 @@ func uncompress(tarball, targetDir string, maxFileSize int64) ([]string, error) 
 		return nil, fmt.Errorf("cannot seek file: %w", err)
 	}
 
-	if !filetype.Is(header, "zst") {
+	if !bytes.Equal(header, zstdMagic) {
 		return nil, fmt.Errorf("unknown file format when trying to uncompress %s", tarball)
 	}
 


### PR DESCRIPTION
## Summary

3rd partyライブラリの削減活動

- `h2non/filetype` ライブラリを zstd マジックバイト直接比較（`0x28, 0xB5, 0x2F, 0xFD`）に置き換え
- ヘッダ読み取りサイズを 262 → 4 バイトに最適化
- `go.mod` / `go.sum` から `h2non/filetype v1.1.3` 依存を除去

## Why

数百種類のファイルタイプマッチャーを持つライブラリを、たった4バイトの比較のためだけに使用していた。zstd のマジックナンバーは RFC 8478 で定義されており、直接比較で十分。

## RFC 8478 根拠

### Section 3.1.1 — Zstandard Frames

> **Magic_Number**: 4 bytes, little-endian format. Value: **0xFD2FB528**.

リトルエンディアン表現のバイト列: `{0x28, 0xB5, 0x2F, 0xFD}` — 本PRの `zstdMagic` と一致。

ref: https://datatracker.ietf.org/doc/html/rfc8478#section-3.1.1

### Skippable Frames（Section 3.1.2）の非対応について

RFC 8478 では Skippable Frame（Magic: `0x184D2A50` 〜 `0x184D2A5F`）も定義されているが、本PRでは検出対象外とした。

- 標準的な zstd compressor（klauspost/compress 含む）は Standard Frame で出力する
- このパッケージ自身の `Compress()` も Standard Frame を生成する
- `zstd.NewReader()` 自体が非 zstd 入力時にエラーを返すため、defense-in-depth として十分

## Test plan
- [x] `go test ./zstdx/...` — 既存テスト全件パス
- [x] `go vet ./...` — 静的解析エラーなし
- [x] `go mod tidy` — `h2non/filetype` が除去されていることを確認

https://tier4.atlassian.net/browse/T4DEV-51848