### PR TITLE
ci: add github-actions ecosystem to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,3 +43,11 @@ updates:
         update-types:
           - "patch"
           - "minor"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "thursday"
+      time: "07:00"
+      timezone: "Asia/Tokyo"


### PR DESCRIPTION
## Summary

- `dependabot.yml` に `github-actions` エコシステムを追加
- GitHub Actions のコミット SHA ピン留めを Dependabot が毎週自動更新するようになる

## Background

サプライチェーンリスク低減の一環で GitHub Actions をコミット SHA にピン留めしたが、`dependabot.yml` に `github-actions` エコシステムの設定がなかったため、今後のバージョンアップが手動対応になっていた。本 PR でその漏れを解消する。

## Test plan

- [ ] Dependabot が `github-actions` エコシステムの PR を自動作成することを確認（次の木曜以降）