### PR TITLE
ci: use GitHub App token to push bunx go.sum fix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,17 +86,27 @@ jobs:
     #
     # This job automatically runs `go mod tidy` in bunx/ and pushes the updated
     # go.sum back to the Dependabot PR branch so that subsequent CI runs pass.
-    # run_attempt == 1: auto re-run is triggered at most once (on the first failure).
-    # On attempt 2+, this job is skipped even if unit-bunx still fails.
+    #
+    # A GitHub App token is used for the push because pushes made with the default
+    # GITHUB_TOKEN do not trigger new workflow runs (a GitHub safeguard against
+    # infinite loops). The App token makes the push appear as a regular user push,
+    # which re-runs Test and Lint against the fixed commit.
     if: failure() && github.actor == 'dependabot[bot]' && github.run_attempt == 1
     permissions:
-      contents: write
+      contents: read
     steps:
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.DEPENDABOT_FIX_APP_ID }}
+          private-key: ${{ secrets.DEPENDABOT_FIX_PRIVATE_KEY }}
+
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -108,7 +118,6 @@ jobs:
         run: go mod tidy
 
       - name: Commit and push if changed
-        id: commit
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -116,11 +125,4 @@ jobs:
           if ! git diff --staged --quiet; then
             git commit -m "chore(bunx): go mod tidy after dockertestx dependency update"
             git push
-            echo "changed=true" >> $GITHUB_OUTPUT
           fi
-
-      - name: Re-run failed jobs if go.sum was fixed
-        if: steps.commit.outputs.changed == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh run rerun ${{ github.run_id }} --failed


### PR DESCRIPTION
## Summary

`fix-bunx-go-sum` ジョブが PR #213 で機能せず CI が trigger されなかった問題を修正する。

### 既存の設計の問題点

1. `gh run rerun ${{ github.run_id }} --failed` が `Resource not accessible by integration` で失敗 (GITHUB_TOKEN が `actions: write` を持たないため)
2. 仮に rerun に成功したとしても、rerun は元の SHA を再 checkout するため、go mod tidy で修正した `bunx/go.sum` は反映されない
3. GITHUB_TOKEN による push は新たな workflow run を trigger しない (GitHub の無限ループ防止仕様)

### 変更

- `actions/create-github-app-token` で GitHub App token を生成
- checkout / push を App token で行う (App identity の push なので、後続の Test / Lint が新しい commit に対して走る)
- 不要になった `Re-run failed jobs` ステップを削除
- workflow の `permissions` を `contents: write` → `contents: read` に縮小 (push は App token を使うため)

### リポジトリ側で必要な設定

このワークフローを動かすには **GitHub App を作成して以下を設定する必要があります**:

1. **GitHub App** を作成
   - Permissions:
     - Repository → Contents: Read & write
     - Repository → Pull requests: Read (※ Dependabot PR への push に必要なら)
   - このリポジトリ (`tier4/x-go`) にインストール
2. リポジトリの **Variables** に `DEPENDABOT_FIX_APP_ID` を追加 (App の App ID)
3. リポジトリの **Secrets** に `DEPENDABOT_FIX_PRIVATE_KEY` を追加 (App の Private key)

App 設定が無い場合、`fix-bunx-go-sum` ジョブは `Generate App token` ステップで失敗するが、これは元々失敗時の補助ジョブなので影響は限定的。

## Test plan

- [ ] GitHub App を作成し、variables / secrets を設定する
- [ ] Dependabot が次に dockertestx の依存を bump した PR で `fix-bunx-go-sum` が動作し、push 後に Test / Lint が新しい commit に対して走り、自動 pass することを確認