### PR TITLE
fix(dockertestx): use errors.Join to properly aggregate ForcePurge errors

### DIFF
--- a/dockertestx/pool.go
+++ b/dockertestx/pool.go
@@ -84,11 +84,7 @@ func (p *Pool) ForcePurge() error {
 			continue
 		}
 		if e := p.Pool.Purge(s.r); e != nil {
-			if err == nil {
-				err = e
-			} else {
-				err = fmt.Errorf("%s: %w", err, err)
-			}
+			err = errors.Join(err, e)
 		}
 	}
 	return err


### PR DESCRIPTION
## Summary

- `ForcePurge` was calling `fmt.Errorf("%s: %w", err, err)` which self-wraps `err` and discards the new error `e`
- Replace the hand-rolled conditional with `errors.Join(err, e)` so all purge errors are accumulated correctly

## Test plan

- [ ] `go vet ./...` passes
- [ ] `go build ./...` passes
- [ ] CI integration tests pass