### PR TITLE
fix(zstdx): reject files exceeding maxFileSize instead of truncating

### DIFF
--- a/zstdx/zstdx.go
+++ b/zstdx/zstdx.go
@@ -116,8 +116,15 @@ func untarFile(tarReader *tar.Reader, header *tar.Header, path string, maxFileSi
 	}
 	defer file.Close()
 
-	if _, err = io.CopyN(file, tarReader, maxFileSize); err != nil && err != io.EOF {
+	// Copy at most maxFileSize+1 bytes so an entry that exceeds the limit is
+	// detected and rejected instead of being silently truncated
+	// (decompression-bomb protection).
+	written, err := io.CopyN(file, tarReader, maxFileSize+1)
+	if err != nil && err != io.EOF {
 		return err
+	}
+	if written > maxFileSize {
+		return fmt.Errorf("file %q exceeds the maximum allowed size of %d bytes", header.Name, maxFileSize)
 	}
 
 	return nil

--- a/zstdx/zstdx_test.go
+++ b/zstdx/zstdx_test.go
@@ -39,7 +39,7 @@ func TestUncompressWithCustomSizeLimit(t *testing.T) {
 	require.NoError(t, os.WriteFile(
 		filepath.Join(srcDir, "data.txt"),
 		bytes.Repeat([]byte("a"), contentSize),
-		0o644,
+		0o600,
 	))
 	tarball := filepath.Join(t.TempDir(), "archive.tar.zst")
 	require.NoError(t, zstdx.Compress(srcDir, tarball))

--- a/zstdx/zstdx_test.go
+++ b/zstdx/zstdx_test.go
@@ -1,7 +1,9 @@
 package zstdx_test
 
 import (
+	"bytes"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -30,22 +32,56 @@ func TestUncompress(t *testing.T) {
 }
 
 func TestUncompressWithCustomSizeLimit(t *testing.T) {
-	// Create a temporary directory to store the output
-	tmpDir, err := os.MkdirTemp("", "uncompress-custom-")
-	defer os.RemoveAll(tmpDir)
-	require.NoError(t, err)
+	// Build a tarball containing a single file of a known size so the size
+	// limit can be exercised precisely.
+	const contentSize = 2048
+	srcDir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(srcDir, "data.txt"),
+		bytes.Repeat([]byte("a"), contentSize),
+		0o644,
+	))
+	tarball := filepath.Join(t.TempDir(), "archive.tar.zst")
+	require.NoError(t, zstdx.Compress(srcDir, tarball))
 
-	// Uncompress the tarball
-	files, err := zstdx.UncompressWithCustomSizeLimit("testdata/sample.tar.zst", tmpDir, 1024)
-	require.NoError(t, err)
+	t.Run("succeeds", func(t *testing.T) {
+		tests := map[string]struct {
+			maxFileSize int64
+		}{
+			"limit equal to file size":    {maxFileSize: contentSize},
+			"limit larger than file size": {maxFileSize: contentSize * 2},
+		}
+		for name, tt := range tests {
+			t.Run(name, func(t *testing.T) {
+				outDir := t.TempDir()
+				files, err := zstdx.UncompressWithCustomSizeLimit(tarball, outDir, tt.maxFileSize)
+				require.NoError(t, err)
+				require.NotEmpty(t, files)
+				// The content must be fully extracted, not silently truncated.
+				for _, f := range files {
+					info, err := os.Stat(f)
+					require.NoError(t, err)
+					assert.Equal(t, int64(contentSize), info.Size())
+				}
+			})
+		}
+	})
 
-	// Check if the files are correctly uncompressed
-	assert.Equal(t, 2, len(files), "Expected two files to be uncompressed")
-	for _, f := range files {
-		info, err := os.Stat(f)
-		require.NoError(t, err)
-		assert.False(t, info.IsDir(), "Expected a file, not a directory")
-	}
+	t.Run("fails", func(t *testing.T) {
+		tests := map[string]struct {
+			maxFileSize int64
+		}{
+			"limit one byte below file size": {maxFileSize: contentSize - 1},
+			"limit far below file size":      {maxFileSize: 10},
+		}
+		for name, tt := range tests {
+			t.Run(name, func(t *testing.T) {
+				outDir := t.TempDir()
+				_, err := zstdx.UncompressWithCustomSizeLimit(tarball, outDir, tt.maxFileSize)
+				require.Error(t, err)
+			})
+		}
+	})
 }
 
 func TestCompress(t *testing.T) {


### PR DESCRIPTION
## Summary

`zstdx.untarFile` enforced the per-file size limit with `io.CopyN(file, tarReader, maxFileSize)`. Because `io.CopyN` copies *exactly* `n` bytes and returns a `nil` error when the source has more, any entry larger than `maxFileSize` was **silently truncated** and still appended to the list of extracted files as if extraction had succeeded.

This had two consequences:

- **Data loss** — oversized files were quietly cut to the limit with no error.
- **Decompression-bomb protection failed** — the limit could never actually reject an entry, defeating its purpose.

## Fix

- Copy `maxFileSize+1` bytes and return an error when `written > maxFileSize`, so an oversized entry is rejected instead of truncated. Files exactly at the limit are still allowed.
- Rewrite `TestUncompressWithCustomSizeLimit` to build a tarball containing a known-size file (via `Compress`) and exercise the limit with `succeeds`/`fails` table-driven subtests, including the boundary case and a check that extracted content is not truncated.

## Test

```
go test ./zstdx/...
```

Verified the new test fails against the old (buggy) code and passes with the fix.