### PR TITLE
fix(zstdx)!: cap total extraction size and entry count to prevent decompression bombs

### DIFF
--- a/zstdx/zstdx.go
+++ b/zstdx/zstdx.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -185,8 +186,13 @@ func untarFile(tarReader *tar.Reader, header *tar.Header, path string, maxFileSi
 	// Copy at most one byte beyond the smaller of the per-file limit and the
 	// remaining total budget, so an entry that exceeds either limit is detected
 	// and rejected instead of being silently truncated or exhausting the disk
-	// (decompression-bomb protection).
-	copyLimit := min(maxFileSize, remainingTotal) + 1
+	// (decompression-bomb protection). Guard the +1 against int64 overflow: when
+	// the limit is math.MaxInt64 (used to effectively disable a cap), adding one
+	// would wrap to a negative count, making io.CopyN silently copy nothing.
+	copyLimit := min(maxFileSize, remainingTotal)
+	if copyLimit < math.MaxInt64 {
+		copyLimit++
+	}
 	written, err := io.CopyN(file, tarReader, copyLimit)
 	if err != nil && err != io.EOF {
 		return written, err

--- a/zstdx/zstdx.go
+++ b/zstdx/zstdx.go
@@ -16,20 +16,70 @@ import (
 var zstdMagic = []byte{0x28, 0xB5, 0x2F, 0xFD}
 
 // For protection from decompression bomb
-const defaultMaxFileSize int64 = 16 * 1024 * 1024 * 1024
+const (
+	defaultMaxFileSize  int64 = 16 * 1024 * 1024 * 1024 // per-file uncompressed size cap
+	defaultMaxTotalSize int64 = 64 * 1024 * 1024 * 1024 // cumulative uncompressed size cap
+	defaultMaxEntries   int   = 1_000_000               // max number of tar entries
+)
 
-// Uncompress with a default max file size limit
-func Uncompress(tarball, targetDir string) ([]string, error) {
-	return uncompress(tarball, targetDir, defaultMaxFileSize)
+// Limits bounds resource usage during extraction to protect against
+// decompression bombs. A non-positive field falls back to its default, so a
+// zero-value Limits is equivalent to DefaultLimits().
+type Limits struct {
+	// MaxFileSize is the maximum uncompressed size of a single entry, in bytes.
+	MaxFileSize int64
+	// MaxTotalSize is the maximum cumulative uncompressed size across all
+	// entries, in bytes.
+	MaxTotalSize int64
+	// MaxEntries is the maximum number of tar entries (directories and files)
+	// that may be processed.
+	MaxEntries int
 }
 
-// UncompressWithCustomSizeLimit with a specified max file size limit
+// DefaultLimits returns the default extraction limits.
+func DefaultLimits() Limits {
+	return Limits{
+		MaxFileSize:  defaultMaxFileSize,
+		MaxTotalSize: defaultMaxTotalSize,
+		MaxEntries:   defaultMaxEntries,
+	}
+}
+
+// withDefaults replaces any non-positive field with its default value.
+func (l Limits) withDefaults() Limits {
+	if l.MaxFileSize <= 0 {
+		l.MaxFileSize = defaultMaxFileSize
+	}
+	if l.MaxTotalSize <= 0 {
+		l.MaxTotalSize = defaultMaxTotalSize
+	}
+	if l.MaxEntries <= 0 {
+		l.MaxEntries = defaultMaxEntries
+	}
+	return l
+}
+
+// Uncompress with the default extraction limits (see DefaultLimits).
+func Uncompress(tarball, targetDir string) ([]string, error) {
+	return uncompress(tarball, targetDir, DefaultLimits())
+}
+
+// UncompressWithCustomSizeLimit with a specified per-file max size limit. The
+// total-size and entry-count limits use their defaults.
 func UncompressWithCustomSizeLimit(tarball, targetDir string, maxFileSize int64) ([]string, error) {
-	return uncompress(tarball, targetDir, maxFileSize)
+	return uncompress(tarball, targetDir, Limits{MaxFileSize: maxFileSize})
+}
+
+// UncompressWithLimits with fully customized extraction limits. Any
+// non-positive field in limits falls back to its default.
+func UncompressWithLimits(tarball, targetDir string, limits Limits) ([]string, error) {
+	return uncompress(tarball, targetDir, limits)
 }
 
 // The code at https://go.dev/play/p/A2GXsDFWx9m is used as a reference
-func uncompress(tarball, targetDir string, maxFileSize int64) ([]string, error) {
+func uncompress(tarball, targetDir string, limits Limits) ([]string, error) {
+	limits = limits.withDefaults()
+
 	file, err := os.Open(filepath.Clean(tarball))
 	if err != nil {
 		return nil, err
@@ -56,12 +106,15 @@ func uncompress(tarball, targetDir string, maxFileSize int64) ([]string, error) 
 	if err != nil {
 		return nil, err
 	}
-	return untar(reader, targetDir, maxFileSize)
+	return untar(reader, targetDir, limits)
 }
 
-func untar(reader io.Reader, targetDir string, maxFileSize int64) ([]string, error) {
+func untar(reader io.Reader, targetDir string, limits Limits) ([]string, error) {
 	var extractedFiles []string
 	tarReader := tar.NewReader(reader)
+
+	var totalWritten int64
+	var entries int
 
 	for {
 		header, err := tarReader.Next()
@@ -77,6 +130,13 @@ func untar(reader io.Reader, targetDir string, maxFileSize int64) ([]string, err
 		// if the header is nil, just skip it (not sure how this happens)
 		case header == nil:
 			continue
+		}
+
+		// Bound the number of entries to protect against archives with a huge
+		// number of (possibly tiny) files or directories.
+		entries++
+		if entries > limits.MaxEntries {
+			return nil, fmt.Errorf("archive exceeds the maximum allowed number of entries (%d)", limits.MaxEntries)
 		}
 
 		// the target location where the dir/file should be created
@@ -97,37 +157,45 @@ func untar(reader io.Reader, targetDir string, maxFileSize int64) ([]string, err
 		// if it's a file create it
 		case tar.TypeReg, tar.TypeGNUSparse:
 			// tar.Next() will externally only iterate files, so we might have to create intermediate directories here
-			if err := untarFile(tarReader, header, path, maxFileSize); err != nil {
+			written, err := untarFile(tarReader, header, path, limits.MaxFileSize, limits.MaxTotalSize-totalWritten)
+			if err != nil {
 				return nil, err
+			}
+			totalWritten += written
+			// Bound the cumulative uncompressed size across all entries.
+			if totalWritten > limits.MaxTotalSize {
+				return nil, fmt.Errorf("archive exceeds the maximum allowed total uncompressed size of %d bytes", limits.MaxTotalSize)
 			}
 			extractedFiles = append(extractedFiles, path)
 		}
 	}
 }
 
-func untarFile(tarReader *tar.Reader, header *tar.Header, path string, maxFileSize int64) error {
+func untarFile(tarReader *tar.Reader, header *tar.Header, path string, maxFileSize, remainingTotal int64) (int64, error) {
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-		return err
+		return 0, err
 	}
 
 	file, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, header.FileInfo().Mode()|0444)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	defer file.Close()
 
-	// Copy at most maxFileSize+1 bytes so an entry that exceeds the limit is
-	// detected and rejected instead of being silently truncated
+	// Copy at most one byte beyond the smaller of the per-file limit and the
+	// remaining total budget, so an entry that exceeds either limit is detected
+	// and rejected instead of being silently truncated or exhausting the disk
 	// (decompression-bomb protection).
-	written, err := io.CopyN(file, tarReader, maxFileSize+1)
+	copyLimit := min(maxFileSize, remainingTotal) + 1
+	written, err := io.CopyN(file, tarReader, copyLimit)
 	if err != nil && err != io.EOF {
-		return err
+		return written, err
 	}
 	if written > maxFileSize {
-		return fmt.Errorf("file %q exceeds the maximum allowed size of %d bytes", header.Name, maxFileSize)
+		return written, fmt.Errorf("file %q exceeds the maximum allowed size of %d bytes", header.Name, maxFileSize)
 	}
 
-	return nil
+	return written, nil
 }
 
 // cf. https://snyk.io/research/zip-slip-vulnerability

--- a/zstdx/zstdx_test.go
+++ b/zstdx/zstdx_test.go
@@ -2,6 +2,7 @@ package zstdx_test
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -78,6 +79,81 @@ func TestUncompressWithCustomSizeLimit(t *testing.T) {
 			t.Run(name, func(t *testing.T) {
 				outDir := t.TempDir()
 				_, err := zstdx.UncompressWithCustomSizeLimit(tarball, outDir, tt.maxFileSize)
+				require.Error(t, err)
+			})
+		}
+	})
+}
+
+func TestUncompressWithLimits(t *testing.T) {
+	// buildTarball writes fileCount files of fileSize bytes each into a fresh
+	// source directory and compresses it into a tarball, returning the tarball
+	// path. The resulting archive has fileCount file entries plus one directory
+	// entry for the root.
+	buildTarball := func(t *testing.T, fileCount int, fileSize int) string {
+		t.Helper()
+		srcDir := t.TempDir()
+		for i := 0; i < fileCount; i++ {
+			require.NoError(t, os.WriteFile(
+				filepath.Join(srcDir, fmt.Sprintf("data%d.txt", i)),
+				bytes.Repeat([]byte("a"), fileSize),
+				0o600,
+			))
+		}
+		tarball := filepath.Join(t.TempDir(), "archive.tar.zst")
+		require.NoError(t, zstdx.Compress(srcDir, tarball))
+		return tarball
+	}
+
+	t.Run("succeeds", func(t *testing.T) {
+		const fileCount = 4
+		const fileSize = 1024
+		tarball := buildTarball(t, fileCount, fileSize)
+
+		tests := map[string]zstdx.Limits{
+			"generous limits": {
+				MaxFileSize:  fileSize,
+				MaxTotalSize: fileCount * fileSize,
+				MaxEntries:   fileCount + 1, // files + root directory
+			},
+			"zero-value limits fall back to defaults": {},
+		}
+		for name, limits := range tests {
+			t.Run(name, func(t *testing.T) {
+				outDir := t.TempDir()
+				files, err := zstdx.UncompressWithLimits(tarball, outDir, limits)
+				require.NoError(t, err)
+				assert.Len(t, files, fileCount)
+				for _, f := range files {
+					info, err := os.Stat(f)
+					require.NoError(t, err)
+					assert.Equal(t, int64(fileSize), info.Size())
+				}
+			})
+		}
+	})
+
+	t.Run("fails", func(t *testing.T) {
+		const fileCount = 4
+		const fileSize = 1024
+		tarball := buildTarball(t, fileCount, fileSize)
+
+		tests := map[string]zstdx.Limits{
+			"total size below cumulative size": {
+				MaxFileSize:  fileSize,               // each file is within the per-file cap
+				MaxTotalSize: fileCount*fileSize - 1, // but the sum exceeds the total cap
+				MaxEntries:   fileCount + 1,
+			},
+			"entry count below number of entries": {
+				MaxFileSize:  fileSize,
+				MaxTotalSize: fileCount * fileSize,
+				MaxEntries:   fileCount, // one short: files + root directory exceed this
+			},
+		}
+		for name, limits := range tests {
+			t.Run(name, func(t *testing.T) {
+				outDir := t.TempDir()
+				_, err := zstdx.UncompressWithLimits(tarball, outDir, limits)
 				require.Error(t, err)
 			})
 		}

--- a/zstdx/zstdx_test.go
+++ b/zstdx/zstdx_test.go
@@ -3,6 +3,7 @@ package zstdx_test
 import (
 	"bytes"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"testing"
@@ -117,6 +118,14 @@ func TestUncompressWithLimits(t *testing.T) {
 				MaxEntries:   fileCount + 1, // files + root directory
 			},
 			"zero-value limits fall back to defaults": {},
+			// math.MaxInt64 is the documented way to effectively disable a cap.
+			// It exercises the copyLimit overflow guard in untarFile: without the
+			// guard, +1 wraps negative and io.CopyN silently extracts 0 bytes.
+			"max-int limits disable caps without truncation": {
+				MaxFileSize:  math.MaxInt64,
+				MaxTotalSize: math.MaxInt64,
+				MaxEntries:   fileCount + 1,
+			},
 		}
 		for name, limits := range tests {
 			t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

`zstdx` extraction previously enforced only a **per-file** size limit, so an archive could still exhaust disk space or inodes via:
- many files each under the per-file cap whose **cumulative** size is huge, or
- a very large number of (possibly tiny) files / directory entries.

This change adds two new caps and rejects archives that exceed them.

## Changes

- New exported `Limits{MaxFileSize, MaxTotalSize, MaxEntries}` struct, `DefaultLimits()`, and `UncompressWithLimits()`.
- Defaults: per-file **16 GiB** (unchanged), total **64 GiB**, entries **1,000,000**. Any non-positive field falls back to its default (zero-value `Limits` == defaults).
- `untar` now tracks cumulative written bytes and an entry counter (directories + files), returning an error when `MaxTotalSize` or `MaxEntries` is exceeded.
- `untarFile` bounds each copy by `min(maxFileSize, remainingTotal)+1`, so a single entry cannot overshoot the remaining total budget, and returns bytes written for accounting.
- `Uncompress` and `UncompressWithCustomSizeLimit` keep their signatures, now applying the new caps with default values.

## ⚠ Breaking change (behavioral)

No exported signatures changed, so existing code still **compiles**. However, the **runtime behavior** of `Uncompress` and `UncompressWithCustomSizeLimit` changes: they now also enforce the default total-size (64 GiB) and entry-count (1,000,000) caps. An archive that exceeds those limits — which previously extracted successfully — will now return an error.

### How to adapt

- Most callers are unaffected: the defaults are generous and only very large archives are rejected.
- To extract archives larger than the defaults, switch to `UncompressWithLimits` and raise the relevant caps:

  \`\`\`go
  files, err := zstdx.UncompressWithLimits(tarball, dst, zstdx.Limits{
      MaxFileSize:  16 << 30,        // keep or adjust the per-file cap
      MaxTotalSize: 512 << 30,       // raise the total cap as needed
      MaxEntries:   5_000_000,       // raise the entry cap as needed
  })
  \`\`\`

- Non-positive fields fall back to the **defaults**, not to "unlimited". To effectively disable a specific cap, set it to a large value such as \`math.MaxInt64\`.

## Tests

- New \`TestUncompressWithLimits\` with \`succeeds\` / \`fails\` subtests: generous-limits and zero-value-defaults succeed; total-size-below-cumulative and entry-count-below-actual fail.

## Verification

- \`go test ./zstdx/...\`, \`go vet ./zstdx/...\`, \`go build ./...\`, \`gofmt\` all clean.