### PR TITLE
fix(zstdx): capture writer Close errors in Compress

### DIFF
--- a/zstdx/zstdx.go
+++ b/zstdx/zstdx.go
@@ -139,21 +139,30 @@ func SanitizeExtractPath(filePath, destination string) (string, error) {
 	return path, nil
 }
 
-func Compress(src, dest string) error {
+func Compress(src, dest string) (err error) {
+	// zstd/tar buffer data and flush on Close, so a Close failure means the
+	// archive may be truncated/corrupted. Capture the first non-nil error so a
+	// flush failure is reported without masking the original error.
+	closeWith := func(c io.Closer) {
+		if cerr := c.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
+	}
+
 	out, err := os.Create(dest)
 	if err != nil {
 		return err
 	}
-	defer out.Close()
+	defer closeWith(out)
 
 	enc, err := zstd.NewWriter(out)
 	if err != nil {
 		return err
 	}
-	defer enc.Close()
+	defer closeWith(enc)
 
 	tarWriter := tar.NewWriter(enc)
-	defer tarWriter.Close()
+	defer closeWith(tarWriter)
 
 	root, err := os.OpenRoot(src)
 	if err != nil {


### PR DESCRIPTION
## Summary

`Compress` ignored the `Close()` errors of the output file, the zstd encoder, and the tar writer. Since zstd and tar buffer data and perform their final flush on `Close()`, a flush failure (e.g. disk full) went undetected and a **truncated/corrupted archive could be returned as success**.

## Changes

- Change the signature to `func Compress(src, dest string) (err error)` (named return).
- Add a `closeWith` helper that captures the **first** non-nil `Close()` error without masking the original error.
- Close order is preserved (`tarWriter` -> `enc` -> `out`) via defer LIFO so flushing happens inner-to-outer.

Read-only closers (`root.Close()`, per-file `data.Close()`) are out of scope and left unchanged.

## Testing

- `go vet ./zstdx/...`
- `go build ./zstdx/...`
- `go test ./zstdx/...`