### PR TITLE
chore: add gitleaks pre-commit hook

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,25 +1,16 @@
-# gitleaks 設定ファイル（pre-commit / GitHub Actions 共通）
+# gitleaks config (shared by pre-commit / GitHub Actions)
 # docs: https://github.com/gitleaks/gitleaks#configuration
 title = "gitleaks config"
 
-# gitleaks 同梱のデフォルトルールセットをベースに拡張する。
+# Extend the ruleset bundled with gitleaks.
 [extend]
 useDefault = true
 
-# --- 追加ルール例 ---------------------------------------------------------
-# Tier IV 固有の token prefix 等を検知したい場合の雛形。
-# 実際の token 体系に合わせて regex を調整、不要なら丸ごと削除する。
-# [[rules]]
-# id = "tier4-internal-token"
-# description = "Tier IV internal service token"
-# regex = '''(?i)t4_(?:prod|stg|dev)_[A-Za-z0-9]{32,}'''
-# tags = ["tier4", "internal"]
-
-# --- 誤検知対策（allowlist）必要に応じてコメントをはずして有効にしてください ---
+# --- False-positive suppression (allowlist): uncomment as needed ----------
 # [allowlist]
 # description = "Global allowlist"
 
-## スキャン対象から除外するパス（テスト用 fixture・サンプル等）
+## Paths to exclude from scanning (test fixtures, samples, etc.)
 # paths = [
 #  '''\.gitleaks\.toml$''',
 #  '''(?i)tests?/.*fixtures?/''',
@@ -29,7 +20,7 @@ useDefault = true
 #  '''(?i)CHANGELOG\.md$''',
 # ]
 
-# 明らかにダミーと分かる値（AWS 公式ドキュメントのサンプルキー等）
+# Values that are clearly dummies (e.g. sample keys from AWS official docs)
 # regexes = [
 #   '''AKIAIOSFODNN7EXAMPLE''',
 #   '''wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY''',

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,36 @@
+# gitleaks 設定ファイル（pre-commit / GitHub Actions 共通）
+# docs: https://github.com/gitleaks/gitleaks#configuration
+title = "gitleaks config"
+
+# gitleaks 同梱のデフォルトルールセットをベースに拡張する。
+[extend]
+useDefault = true
+
+# --- 追加ルール例 ---------------------------------------------------------
+# Tier IV 固有の token prefix 等を検知したい場合の雛形。
+# 実際の token 体系に合わせて regex を調整、不要なら丸ごと削除する。
+# [[rules]]
+# id = "tier4-internal-token"
+# description = "Tier IV internal service token"
+# regex = '''(?i)t4_(?:prod|stg|dev)_[A-Za-z0-9]{32,}'''
+# tags = ["tier4", "internal"]
+
+# --- 誤検知対策（allowlist）必要に応じてコメントをはずして有効にしてください ---
+# [allowlist]
+# description = "Global allowlist"
+
+## スキャン対象から除外するパス（テスト用 fixture・サンプル等）
+# paths = [
+#  '''\.gitleaks\.toml$''',
+#  '''(?i)tests?/.*fixtures?/''',
+#  '''(?i)testdata/''',
+#  '''\.example$''',
+#  '''\.sample$''',
+#  '''(?i)CHANGELOG\.md$''',
+# ]
+
+# 明らかにダミーと分かる値（AWS 公式ドキュメントのサンプルキー等）
+# regexes = [
+#   '''AKIAIOSFODNN7EXAMPLE''',
+#   '''wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY''',
+# ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+minimum_pre_commit_version: "3.5.0"
+
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,10 @@ deps: ## download dependencies
 	find . -name go.mod -execdir $(GO) mod download \;
 	find . -name go.mod -execdir $(GO) mod tidy \;
 
+.PHONY: setup
+setup: deps ## setup dev environment (deps + pre-commit hook)
+	pre-commit install
+
 .PHONY: test
 test: unit-test ## test all
 

--- a/README.md
+++ b/README.md
@@ -5,3 +5,35 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/tier4/x-go)](https://goreportcard.com/report/github.com/tier4/x-go)
 
 Shared libraries used in the TIER IV. Use at your own risk. Breaking changes should be anticipated.
+
+## Development
+
+### Setup
+
+This repository uses [mise](https://mise.jdx.dev/) to manage development tooling. The standard setup is:
+
+```sh
+mise install
+```
+
+`mise install` installs the pinned tools (currently `pre-commit`) and runs `pre-commit install` through the `postinstall` hook, so the local secret-scan hook is enabled in one step.
+
+Pin your personal tool versions (Go, etc.) in `mise.local.toml`; the shared `mise.toml` intentionally manages only `pre-commit`.
+
+> If your local git has `core.hooksPath` set, `pre-commit install` is refused and the hook is not installed automatically. In that case run `pre-commit run --all-files` manually (or unset `core.hooksPath`).
+
+If you don't use mise, run the equivalent:
+
+```sh
+make setup
+```
+
+### Secret scan (gitleaks)
+
+Layer 1 of the secret-scanning guardrail: a local [gitleaks](https://github.com/gitleaks/gitleaks) hook runs on `git commit` via [pre-commit](https://pre-commit.com/) to block secrets before they enter the history.
+
+- Config: `.pre-commit-config.yaml`, `.gitleaks.toml` (extends the default ruleset with `useDefault = true`).
+- Enabled automatically by `mise install` (or `make setup`).
+- Run manually: `pre-commit run gitleaks --all-files`.
+
+This local hook is best-effort and can be bypassed with `git commit --no-verify`. Effective enforcement is delegated to Layer 2 (CI required check / org ruleset) and GitHub Push Protection.

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,10 @@
+# 共有 mise 設定。secret scan の pre-commit のみを管理する。
+# 個人用ツール（go 等）の pin は mise.local.toml に置くこと。
+[settings]
+experimental = true # [hooks] を有効化するために必要
+
+[tools]
+pre-commit = "4.5.1"
+
+[hooks]
+postinstall = "pre-commit install"


### PR DESCRIPTION
## Summary

Introduces **Layer 1 (local pre-commit defense)** of the secret-scanning guardrail described in the WEB guideline (gitleaks / trufflehog). It blocks secrets locally at `git commit` time, before they enter history.

Only Layer 1 is in scope here. Layer 2 (CI required check / org ruleset) and Layer 3 (periodic TruffleHog scan) are provided as Reusable Workflows in `tier4/WebAutoIaCGitHubActions` and are out of scope for this PR.

## Changes

- `.pre-commit-config.yaml` — gitleaks hook pinned to `rev: v8.30.1`. pre-commit fetches the Go toolchain and builds gitleaks, so no separate install is required.
- `.gitleaks.toml` — extends the bundled default ruleset (`useDefault = true`); templates for extra rules / allowlist are kept as comments for per-repo customization.
- `mise.toml` — pins `pre-commit` and auto-installs the git hook.
- `Makefile` — `setup` target for developers who don't use mise.
- `README.md` — development setup (mise-first) + a Secret scan section.

## Install-forgetfulness countermeasure (chosen approach & side effects)

pre-commit only takes effect once `pre-commit install` has run. To reduce "forgot to install" cases, **mise is the primary path**:

- `mise.toml` pins `pre-commit = "4.5.1"` under `[tools]`.
- `[hooks] postinstall = "pre-commit install"` runs automatically after install (`[settings] experimental = true` is required to enable `[hooks]`).
- → `mise install` installs pre-commit **and** sets up the git hook in one step.
- The shared `mise.toml` manages only `pre-commit`; personal tool pins (Go, etc.) belong in `mise.local.toml` (deliberately **not** added to `.gitignore`).
- `mise.toml` can be hidden by a local `.git/info/exclude`, so it was committed with `git add -f mise.toml`.

As a fallback for non-mise developers, `make setup` runs the existing `deps` flow + `pre-commit install`. The README standard setup leads with `mise install`.

**Side effect / caveat:** if a developer's local git has `core.hooksPath` set, `pre-commit install` is refused (`Cowardly refusing to install hooks with 'core.hooksPath' set`). In that case mise reports it as a **warning only** and `mise install` still exits 0 — the tool is installed, but the git hook is not. Those developers can run `pre-commit run --all-files` manually (or unset `core.hooksPath`). This was exactly the case in the environment where this PR was prepared, so the hook was verified via `pre-commit run` rather than an actual commit.

## Enforcement scope (best-effort)

This local hook is **best-effort**: it can be bypassed with `git commit --no-verify`, and it is not active at all for developers who never run setup. Effective enforcement is intentionally delegated to **Layer 2 (CI required check / org ruleset)** and **GitHub Push Protection** (server-side) — both out of scope for this PR.

## Verification

- Staged all deliverables (including `.gitleaks.toml` itself) and ran `pre-commit run gitleaks` → **Passed**, no false positives. The AWS example keys embedded in `.gitleaks.toml`'s allowlist template are covered by gitleaks' default allowlist, so no allowlist entry needed uncommenting.
- Staged a throwaway file containing a dummy `ghp_…` token and ran `pre-commit run gitleaks` → **Failed (exit 1)**, `RuleID: github-pat`, secret redacted — confirming commits are blocked. The test file was never committed and was deleted.
- `useDefault = true` confirmed active (the finding above came from the bundled ruleset).
- `mise install` confirmed: pre-commit installed; postinstall hook behaved as described above under `core.hooksPath`.
