### PR TITLE
fix(random): avoid panic on negative length and O(n^2) string build

### DIFF
--- a/random/random.go
+++ b/random/random.go
@@ -20,13 +20,18 @@ func GenerateBase58(length int) string {
 	return generateRandomString(letters, length)
 }
 
+const defaultLength = 32
+
 func generateRandomString(letters string, length int) string {
+	if length < 0 {
+		length = defaultLength
+	}
+
 	b := make([]byte, length)
 	_, _ = io.ReadFull(rand.Reader, b)
 
-	var result string
-	for _, v := range b {
-		result += string(letters[int(v)%len(letters)])
+	for i, v := range b {
+		b[i] = letters[int(v)%len(letters)]
 	}
-	return result
+	return string(b)
 }

--- a/random/random_test.go
+++ b/random/random_test.go
@@ -1,6 +1,7 @@
 package random_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -8,17 +9,63 @@ import (
 	"github.com/tier4/x-go/random"
 )
 
+// wantDefaultLength mirrors the unexported defaultLength in random.go, used when a negative length is given.
+const wantDefaultLength = 32
+
 func TestGenerateAlphabets(t *testing.T) {
 	t.Parallel()
-	assert.Regexp(t, "^[a-zA-Z]{50}$", random.GenerateAlphabets(50))
+
+	tests := map[string]struct {
+		length int
+		regexp string
+	}{
+		"positive length": {length: 50, regexp: "^[a-zA-Z]{50}$"},
+		"negative length": {length: -1, regexp: fmt.Sprintf("^[a-zA-Z]{%d}$", wantDefaultLength)},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assert.Regexp(t, tt.regexp, random.GenerateAlphabets(tt.length))
+		})
+	}
 }
 
 func TestGenerateAlphabetsLowerCase(t *testing.T) {
 	t.Parallel()
-	assert.Regexp(t, "^[a-z]{50}$", random.GenerateAlphabetsLowerCase(50))
+
+	tests := map[string]struct {
+		length int
+		regexp string
+	}{
+		"positive length": {length: 50, regexp: "^[a-z]{50}$"},
+		"negative length": {length: -1, regexp: fmt.Sprintf("^[a-z]{%d}$", wantDefaultLength)},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assert.Regexp(t, tt.regexp, random.GenerateAlphabetsLowerCase(tt.length))
+		})
+	}
 }
 
 func TestGenerateBase58(t *testing.T) {
 	t.Parallel()
-	assert.Regexp(t, "^[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{50}$", random.GenerateBase58(50))
+
+	const charset = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+	tests := map[string]struct {
+		length int
+		regexp string
+	}{
+		"positive length": {length: 50, regexp: "^[" + charset + "]{50}$"},
+		"negative length": {length: -1, regexp: fmt.Sprintf("^[%s]{%d}$", charset, wantDefaultLength)},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assert.Regexp(t, tt.regexp, random.GenerateBase58(tt.length))
+		})
+	}
 }


### PR DESCRIPTION
## Summary
- `generateRandomString` panicked when given a negative `length` (`make([]byte, length)` with a negative size)
- The result string was built via repeated `+=` concatenation in a loop, which is O(n^2)

## Changes
- Negative `length` now falls back to a default length of 32 instead of panicking
- Result is built by writing into the preallocated byte slice directly, avoiding the O(n^2) concatenation

## Test plan
- [x] `go test ./random/...` passes, including new cases for negative length input
- [x] `go vet ./random/...`
- [x] `golangci-lint run ./random/...`