### PR TITLE
fix(idx): validate uuid case-insensitively and check version/variant nibbles

### DIFF
--- a/idx/idx.go
+++ b/idx/idx.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	pattern = regexp.MustCompile(`^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$`)
+	pattern = regexp.MustCompile(`^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[1-8][a-fA-F0-9]{3}-[89abAB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$`)
 )
 
 func NewUUID() string {

--- a/idx/idx_test.go
+++ b/idx/idx_test.go
@@ -14,15 +14,27 @@ func TestIsUUIDString(t *testing.T) {
 		expected bool
 	}{
 		"valid": {
-			arg:      "f792d50f-8e11-44ae-cadc-d7b8aeaeecf3",
+			arg:      "f792d50f-8e11-44ae-8adc-d7b8aeaeecf3",
+			expected: true,
+		},
+		"valid uppercase": {
+			arg:      "F792D50F-8E11-44AE-8ADC-D7B8AEAEECF3",
 			expected: true,
 		},
 		"invalid character": {
-			arg:      "z792d50f-8e11-44ae-cadc-d7b8aeaeecf3",
+			arg:      "z792d50f-8e11-44ae-8adc-d7b8aeaeecf3",
 			expected: false,
 		},
 		"invalid length": {
-			arg:      "f792d50f-8e11-44ae-cadc-d7b8aeaeecf",
+			arg:      "f792d50f-8e11-44ae-8adc-d7b8aeaeecf",
+			expected: false,
+		},
+		"invalid version": {
+			arg:      "f792d50f-8e11-94ae-8adc-d7b8aeaeecf3",
+			expected: false,
+		},
+		"invalid variant": {
+			arg:      "f792d50f-8e11-44ae-cadc-d7b8aeaeecf3",
 			expected: false,
 		},
 	} {


### PR DESCRIPTION
## Summary
- `IsUUIDString` rejected valid uppercase UUIDs because its regex only matched lowercase hex.
- It also accepted UUIDs with invalid version/variant nibbles since those positions were unchecked.
- Regex now allows `[a-fA-F0-9]` and requires version nibble `1-8` and variant nibble `8/9/a/b` (case-insensitive).

## Test plan
- [x] `go test ./idx/...`
- [x] `go build ./...`